### PR TITLE
feat: prevent increasing counter state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,21 +34,25 @@ help:
 	@echo "make test - run go test including race detection"
 	@echo "make bench - run go test including benchmarking"
 
-
 .PHONY: format
 format:
 	$(info: Make: Format)
-	@echo go fmt ./...
-	@go fmt ./...
-
+	gofmt -w ./**/*
+	goimports -w ./**/*
+	golines -w ./**/*
 
 .PHONY: test
 test:
+	$(info: Make: Test)
 	CGO_ENABLED=1 go test -race ${TEST_OPTIONS} ${SOURCE_FILES} -run ${TEST_PATTERN} -timeout=${TEST_TIMEOUT}
 
 .PHONY: bench
 bench:
+	$(info: Make: Bench)
 	CGO_ENABLED=1 go test -race ${BENCH_OPTIONS} ${SOURCE_FILES} -run ${TEST_PATTERN} -timeout=${TEST_TIMEOUT}
 
-
-
+.PHONY: setup
+setup:
+	$(info: Make: Setup)
+	go install golang.org/x/tools/cmd/goimports@latest
+	go install github.com/segmentio/golines@latest

--- a/errors.go
+++ b/errors.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	ErrRateLimitExceeded         = errors.New("rate limit exceeded")
 	ErrTokensGreaterThanCapacity = errors.New("tokens are greater than capacity")
+	ErrCannotLoadScript          = errors.New("cannot load LUA script")
 )

--- a/examples/fixed_window/main.go
+++ b/examples/fixed_window/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/go-redis/redis/v8"
-	"github.com/sonirico/pacemaker"
 	"log"
 	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/sonirico/pacemaker"
 )
 
 func main() {

--- a/examples/fixed_window_token_bucket_variant/main.go
+++ b/examples/fixed_window_token_bucket_variant/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/go-redis/redis/v8"
-	"github.com/sonirico/pacemaker"
 	"log"
 	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/sonirico/pacemaker"
 )
 
 func main() {
@@ -35,9 +36,12 @@ func main() {
 				Unit:   rateUnit,
 			},
 			Clock: pacemaker.NewClock(),
-			DB: pacemaker.NewFixedWindowRedisStorage(redisCli, pacemaker.FixedWindowRedisStorageOpts{
-				Prefix: "pacemaker",
-			}),
+			DB: pacemaker.NewFixedWindowRedisStorage(
+				redisCli,
+				pacemaker.FixedWindowRedisStorageOpts{
+					Prefix: "pacemaker",
+				},
+			),
 		}),
 	)
 

--- a/examples/fixed_window_truncated/main.go
+++ b/examples/fixed_window_truncated/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/go-redis/redis/v8"
-	"github.com/sonirico/pacemaker"
 	"log"
 	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/sonirico/pacemaker"
 )
 
 func main() {
@@ -35,9 +36,12 @@ func main() {
 				Unit:   rateUnit,
 			},
 			Clock: pacemaker.NewClock(),
-			DB: pacemaker.NewFixedWindowRedisStorage(redisCli, pacemaker.FixedWindowRedisStorageOpts{
-				Prefix: "pacemaker",
-			}),
+			DB: pacemaker.NewFixedWindowRedisStorage(
+				redisCli,
+				pacemaker.FixedWindowRedisStorageOpts{
+					Prefix: "pacemaker",
+				},
+			),
 		})
 
 	for i := 0; i < 100; i++ {

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,11 @@
 package pacemaker
 
+import (
+	"crypto"
+	"encoding/hex"
+	"strings"
+)
+
 func AtLeast(n int64) func(int64) int64 {
 	return func(m int64) int64 {
 		if m < n {
@@ -7,4 +13,21 @@ func AtLeast(n int64) func(int64) int64 {
 		}
 		return m
 	}
+}
+
+func Sha1Hash(s string) string {
+	data := make([]byte, 0, 40)
+	hasher := crypto.SHA1.New()
+	n, err := hasher.Write([]byte(s))
+	if err != nil {
+		panic(err)
+	}
+	if n != len(s) {
+		panic("insufficient bytes read")
+	}
+	return hex.EncodeToString(hasher.Sum(data))
+}
+
+func errIsRedisNoScript(err error) bool {
+	return strings.HasPrefix(err.Error(), "NOSCRIPT")
 }


### PR DESCRIPTION
Prior to this commit when employing the 'Try' interface, if the call incurred in rate limit, the state counter accumulated payload tokens unnecessarily, making the 'Check' interface to return unexpected values.