### PR TITLE
BREAKING CHANGE: check returns time to wait

### DIFF
--- a/limiter_fixed_truncated_window_test.go
+++ b/limiter_fixed_truncated_window_test.go
@@ -268,28 +268,28 @@ func TestNewFixedTruncatedWindowRateLimiter(t *testing.T) {
 			for i, step := range test.steps {
 				switch step.method {
 				case try:
-					ttw, err := rl.Try(ctx)
+					res, err := rl.Try(ctx)
 
 					if !errors.Is(err, step.expectedErr) {
 						t.Errorf("step(%d) unexpected error, want %v, have %v",
 							i+1, step.expectedErr, err)
 					}
 
-					if ttw != step.expectedTtw {
+					if res.TimeToWait != step.expectedTtw {
 						t.Errorf("step(%d) unexpected time to wait, want %v, have %v",
-							i+1, step.expectedTtw, ttw)
+							i+1, step.expectedTtw, res.TimeToWait)
 					}
 
 				case check:
-					free, err := rl.Check(ctx)
+					res, err := rl.Check(ctx)
 					if !errors.Is(err, step.expectedErr) {
 						t.Errorf("step(%d) unexpected error, want %v, have %v",
 							i+1, step.expectedErr, err)
 					}
 
-					if free != step.expectedFreeSlots {
+					if res.FreeSlots != step.expectedFreeSlots {
 						t.Errorf("step(%d) unexpected free slots, want %d, have %d",
-							i+1, step.expectedFreeSlots, free)
+							i+1, step.expectedFreeSlots, res.FreeSlots)
 					}
 				}
 

--- a/limiter_fixed_window_test.go
+++ b/limiter_fixed_window_test.go
@@ -368,7 +368,8 @@ func TestNewFixedWindowRateLimiter(t *testing.T) {
 			for i, step := range test.steps {
 				switch step.method {
 				case try:
-					ttw, err := rl.Try(ctx)
+					res, err := rl.Try(ctx)
+					ttw := res.TimeToWait
 
 					if !errors.Is(err, step.expectedErr) {
 						t.Errorf("step(%d) unexpected error, want %v, have %v",
@@ -381,11 +382,13 @@ func TestNewFixedWindowRateLimiter(t *testing.T) {
 					}
 
 				case check:
-					free, err := rl.Check(ctx)
+					res, err := rl.Check(ctx)
 					if !errors.Is(err, step.expectedErr) {
 						t.Errorf("step(%d) unexpected error, want %v, have %v",
 							i+1, step.expectedErr, err)
 					}
+
+					free := res.FreeSlots
 
 					if free != step.expectedFreeSlots {
 						t.Errorf("step(%d) unexpected free slots, want %d, have %d",

--- a/limiter_token_fixed_window.go
+++ b/limiter_token_fixed_window.go
@@ -2,12 +2,11 @@ package pacemaker
 
 import (
 	"context"
-	"time"
 )
 
 type fixedWindowRateLimiter interface {
-	try(ctx context.Context, tokens int64) (time.Duration, error)
-	check(ctx context.Context, tokens int64) (int64, error)
+	try(ctx context.Context, tokens int64) (Result, error)
+	check(ctx context.Context, tokens int64) (Result, error)
 	fixedWindow()
 }
 
@@ -21,12 +20,12 @@ type TokenFixedWindowRateLimiter struct {
 
 // Try returns the amount of time to wait when the rate limit has been exceeded. The total amount of tokens consumed
 // by the requests check be given as argument
-func (l *TokenFixedWindowRateLimiter) Try(ctx context.Context, tokens int64) (time.Duration, error) {
+func (l *TokenFixedWindowRateLimiter) Try(ctx context.Context, tokens int64) (Result, error) {
 	return l.fixedWindowRateLimiter.try(ctx, tokens)
 }
 
 // Check returns whether further requests check be made by returning the number of free slots
-func (l *TokenFixedWindowRateLimiter) Check(ctx context.Context, tokens int64) (int64, error) {
+func (l *TokenFixedWindowRateLimiter) Check(ctx context.Context, tokens int64) (Result, error) {
 	return l.fixedWindowRateLimiter.check(ctx, tokens)
 }
 

--- a/models.go
+++ b/models.go
@@ -1,0 +1,18 @@
+package pacemaker
+
+import "time"
+
+type (
+	Result struct {
+		TimeToWait time.Duration
+		FreeSlots  int64
+	}
+)
+
+var (
+	nores = Result{}
+)
+
+func res(ttw time.Duration, slots int64) Result {
+	return Result{TimeToWait: ttw, FreeSlots: slots}
+}


### PR DESCRIPTION
This commit makes both main rate limit APIs to return the 'time to wait' argument so needed for external logic.